### PR TITLE
DATA-2929 - Update to container that's used in app and revert CLI change now that RDK's been released

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Viam CLI
       shell: bash
       run: |
-        curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-latest-linux-amd64
+        curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
         chmod a+rx /usr/local/bin/viam
         viam login api-key --key-id ${{ secrets.VIAM_DEV_API_KEY_ID }} --key ${{ secrets.VIAM_DEV_API_KEY }}
     - name: Download dataset file


### PR DESCRIPTION
Three changes in this PR:
- using the container that's actually used in app for ML training
- defining environment variables for the test script (used in tabular data example, since running the script requires key + key ID)
- reverting the CLI change to be stable instead of latest

(successful workflow run [here](https://github.com/viam-modules/tabular-data-tensorflow/actions/runs/10198972965/job/28215010960?pr=1))