### PR TITLE
Add directive to checkout submodules as well

### DIFF
--- a/.github/workflows/deploy_training_script.yaml
+++ b/.github/workflows/deploy_training_script.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Check out training script code
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Setup Python3.10
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
When checking out the main repo code, also recursively checks out its submodules.

If a repository has no submodules, the submodules: recursive parameter will do nothing and won't cause any errors.