### PR TITLE
Set "version" to be tag from Release if available, otherwise stick with date

### DIFF
--- a/.github/workflows/deploy_training_script.yaml
+++ b/.github/workflows/deploy_training_script.yaml
@@ -59,6 +59,11 @@ jobs:
     - name: Push to Viam Registry
       shell: bash
       run: |
-        viam training-script upload --framework=${{ inputs.framework }} --org-id=${{ secrets.VIAM_ORG_ID }} --path=${{ steps.file-extension.outputs.path_name }} --script-name=${{ inputs.script_name }} --type=${{ inputs.model_type }} --version=$(date -u +'%Y-%m-%dT%H-%M-%S')
+        if [ -n "${{ github.event.release.tag_name }}" ]; then
+          VERSION="${{ github.event.release.tag_name }}"
+        else
+          VERSION=$(date -u +'%Y-%m-%dT%H-%M-%S')
+        fi
+        viam training-script upload --framework=${{ inputs.framework }} --org-id=${{ secrets.VIAM_ORG_ID }} --path=${{ steps.file-extension.outputs.path_name }} --script-name=${{ inputs.script_name }} --type=${{ inputs.model_type }} --version=$VERSION
 
 


### PR DESCRIPTION
This adds a if/else statement that checks to see if the workflow has a tag name that was associated with a release, and uses that tag name as the version. For ML Models trained and deployed through github releases, this will be how to track the versions. 

if the workflow was not caused by a release, then it uses the version it has always used, namely the date