### PR TITLE
add token to checkout private repos

### DIFF
--- a/.github/workflows/deploy_training_script.yaml
+++ b/.github/workflows/deploy_training_script.yaml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
+        token: ${{ github.token }}
     - name: Setup Python3.10
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
Since sometimes the submodule is a private repo, we will need a token in order to checkout the submodule