### PR TITLE
fall back token, if token is empty

### DIFF
--- a/.github/workflows/deploy_training_script.yaml
+++ b/.github/workflows/deploy_training_script.yaml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-        token: ${{ secrets.TOKEN }}
+        token: ${{ secrets.TOKEN || github.token }}
     - name: Setup Python3.10
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
So, even though required: False, the checkout action still requires a token!!!

so github.token is always available, and is a fall back (even though it doesn't work for private repos, at least you can still checkout public repos no problem)