### PR TITLE
Add reusable bump_go_dependencies workflow

### DIFF
--- a/.github/workflows/bump_go_dependencies.yaml
+++ b/.github/workflows/bump_go_dependencies.yaml
@@ -1,0 +1,49 @@
+name: Bump Go Dependencies
+
+on:
+  workflow_call:
+    inputs:
+      packages:
+        description: 'Space-separated list of Go packages to update'
+        type: string
+        default: 'go.viam.com/rdk go.viam.com/api'
+      base:
+        description: 'Base branch for the pull request'
+        type: string
+        default: 'main'
+
+jobs:
+  bump-versions:
+    name: Bump Package Versions
+    if: github.repository_owner == 'viam-modules'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/viamrobotics/rdk-devenv:amd64
+    timeout-minutes: 10
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Update go dependencies
+      id: gobump
+      run: |
+        sudo chown -R testbot .
+        for pkg in ${{ inputs.packages }}; do
+          sudo -u testbot bash -lc "go get $pkg"
+        done
+        sudo -u testbot bash -lc 'go mod tidy'
+        GEN_DIFF=$(git status -s)
+
+        if [ -n "$GEN_DIFF" ]; then
+            echo "needs_pr=1" >> $GITHUB_OUTPUT
+        fi
+    - name: Add + Commit + Open PR
+      if: steps.gobump.outputs.needs_pr == 1
+      uses: peter-evans/create-pull-request@v7
+      with:
+          commit-message: '[WORKFLOW] Updating go dependencies'
+          branch: 'workflow/update-dependencies'
+          delete-branch: true
+          base: ${{ inputs.base }}
+          title: Automated Go Dependencies Update
+          body: This is an auto-generated PR to update go dependencies. Please confirm tests are passing before merging.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ jobs:
 - `test_script_name` (optional, default: `scripts/test.sh`): Path to the test script to run
 - `container_image` (required): The ML training container you will use this script with. Must be one of the supported container names found by calling ListSupportedContainers. An easy way to do this is to run `viam train containers list`.
 
+### Bump Go Dependencies
+
+To keep a Go module's `go.viam.com/rdk` (and `go.viam.com/api`) dependency up to date automatically, add a workflow in `.github/workflows` like:
+
+```
+name: Bump Versions
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '30 17 * * WED' # 12:30 EST on Wednesdays
+  workflow_dispatch:
+
+jobs:
+  bump-versions:
+    uses: viam-modules/common-workflows/.github/workflows/bump_go_dependencies.yaml@main
+```
+
+On each run it updates the requested packages (and only the transitive minimums they require — not all dependencies), runs `go mod tidy`, and opens a PR if anything changed.
+
+**Inputs:**
+- `packages` (optional, default: `go.viam.com/rdk go.viam.com/api`): Space-separated list of Go packages to update
+- `base` (optional, default: `main`): Base branch for the pull request
+
 ### Secrets
 
 These workflows require a few secrets. They have already been set up as github secrets for the `viam-modules` org. So you shouldn't need to do anything special in your new repo. But for transparency, they can be found:


### PR DESCRIPTION
Adds a reusable (`workflow_call`) version of the `bump_dependencies.yml` job that already runs in `uln2003`, `robotiq`, `rplidar`, and `viam-cartographer`, so Go module repos can point at one shared implementation instead of carrying their own copy.

Behavior is identical to the existing job: `go get go.viam.com/rdk`, `go get go.viam.com/api`, `go mod tidy`, then open a PR via `peter-evans/create-pull-request` only if something changed. Only the named packages (and the transitive minimums they require) are updated — this is not `go get -u ./...`.

**Inputs:**
- `packages` (default `go.viam.com/rdk go.viam.com/api`)
- `base` (default `main`)

The cron schedule lives in each calling repo (GitHub doesn't allow `schedule` triggers on `workflow_call` workflows). Follow-up PRs point the 13 Go driver-module repos at this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)